### PR TITLE
IMU heater tuning for type C exposed to open air

### DIFF
--- a/src/tap/communication/sensors/imu_heater/imu_heater.hpp
+++ b/src/tap/communication/sensors/imu_heater/imu_heater.hpp
@@ -61,10 +61,10 @@ private:
     /**
      * PID constants for temperature control.
      */
-    static constexpr float TEMPERATURE_PID_P = 1.0f;
-    static constexpr float TEMPERATURE_PID_I = 0.0f;
-    static constexpr float TEMPERATURE_PID_D = 20.0f;
-    static constexpr float TEMPERATURE_PID_MAX_ERR_SUM = 0.0f;
+    static constexpr float TEMPERATURE_PID_P = 0.12f;
+    static constexpr float TEMPERATURE_PID_I = 0.005f;
+    static constexpr float TEMPERATURE_PID_D = 0.0f; //Derivative control is unwanted on a 1st order system
+    static constexpr float TEMPERATURE_PID_MAX_ERR_SUM = 0.12f / TEMPERATURE_PID_I;
     static constexpr float TEMPERATURE_PID_MAX_OUT = 1.0f;
 
     /**
@@ -77,7 +77,7 @@ private:
      * Normal operating temperature is ~40 degrees C, and RM manual says the optimal operating
      * temperature is ~15-20 degrees C above the normal operating temperature of the board.
      */
-    float imuDesiredTemperature = 50.0f;
+    float imuDesiredTemperature = 35.0f;
 
     Drivers *drivers;
 


### PR DESCRIPTION
Improved type C IMU heater tuning to avoid massive overshoot on startup and reduce oscillations at steady-state. While unable to get a perfect flatline due to poor resolution of the temperature sensor, startup is tuned and you can get a decent calibration about 10s after startup and a good calibration at 30s after startup. I tested the IMU exposed to open air (without a jetson dumping heat onto it).

Removed derivative control from IMU heater due to it being a first order system. Added integral control to the system to eliminate steady-state error and added anti-windup to the modm PID controller because anti-windup is absolutely required for this to work.

Prior to tuning:
![bad_tunings](https://github.com/user-attachments/assets/0abca008-4289-4f60-88ff-c2208dc77622)
After tuning:
![good_tunings](https://github.com/user-attachments/assets/f8747eb8-fc94-4be9-a427-6e1f41b5b238)
